### PR TITLE
Added docker-compose.yaml, more BUILD-ARGS for the Dockerfile and documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /assets
 /tmp
+venv

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,18 +1,24 @@
 # Dockerfile script to download, create and setup a local casper-node CCTL
 # The script is split into two sections across two Debian images:
 # Build: install dependencies, download the source code,
-#  install rust and build the casper-node
+# install rust and build the casper-node
 # Run: install run time dependencies, create a non root user and
-#  copy over the compiled binaries from the build ready for cctl start
+# copy over the compiled binaries from the build ready for cctl start
 FROM debian:buster as build
 
+# Allow users to specify forked node, or specific commit
+# If not fallback to release branch (or alternatively just specify branch)
+ARG NODE_REPO=https://github.com/casper-network/casper-node.git
+ARG NODE_COMMIT=
+ARG CLIENT_REPO=https://github.com/casper-ecosystem/casper-client-rs.git
+ARG CLIENT_COMMIT=
 ARG NODE_GITBRANCH=release-1.5.6
 ARG CLIENT_GITBRANCH=release-2.0.0
 
-RUN apt-get update  \
+RUN apt-get update \
     && DEBIAN_FRONTEND="noninteractive" \
     apt-get install -y sudo tzdata curl gnupg gcc git ca-certificates \
-        protobuf-compiler libprotobuf-dev  \
+        protobuf-compiler libprotobuf-dev \
         pkg-config libssl-dev make build-essential gettext-base lsof cmake\
         && rm -rf /var/lib/apt/lists/*
 
@@ -23,9 +29,17 @@ RUN curl -f -L https://static.rust-lang.org/rustup.sh -O \
 ENV PATH="$PATH:/root/.cargo/bin"
 
 RUN git clone https://github.com/casper-network/casper-node-launcher.git \
-        && git clone -b $CLIENT_GITBRANCH https://github.com/casper-ecosystem/casper-client-rs \
-        && git clone -b $NODE_GITBRANCH https://github.com/casper-network/casper-node.git \
-        && git clone https://github.com/casper-network/cctl.git
+    && git clone https://github.com/casper-network/cctl.git
+RUN if [ -n "$NODE_COMMIT" ]; then \
+        git clone -b $NODE_COMMIT $NODE_REPO; \
+    else \
+        git clone -b $NODE_GITBRANCH $NODE_REPO; \
+    fi \
+    && if [ -n "$CLIENT_COMMIT" ]; then \
+        git clone -b $CLIENT_COMMIT $CLIENT_REPO; \
+    else \
+        git clone -b $CLIENT_GITBRANCH $CLIENT_REPO; \
+    fi
 
 WORKDIR /casper-node
 
@@ -47,7 +61,7 @@ RUN apt-get update \
       && apt-get install -y sudo curl git ca-certificates jq supervisor lsof python3 python3-pip python3-toml \
       && rm -rf /var/lib/apt/lists/*
 
-RUN useradd -ms /bin/bash cctl &&  echo "cctl:cctl" | chpasswd && adduser cctl sudo
+RUN useradd -ms /bin/bash cctl && echo "cctl:cctl" | chpasswd && adduser cctl sudo
 RUN echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
 
 USER cctl

--- a/docker/README.md
+++ b/docker/README.md
@@ -4,51 +4,58 @@ The following instructions enable developers to spin up a local dockerised caspe
 
 ### Build
 
-[TODO: Use docker compose]
-
 After starting docker on your machine follow these simple instructions:
 
+Build and run using `docker build` or `docker compose`:
 ```bash
 git clone git@github.com:casper-network/cctl.git && cd cctl/docker
 
 docker build . --build-arg NODE_GITBRANCH=release-1.5.6 --build-arg CLIENT_GITBRANCH=release-2.0.0 -t cspr-cctl/release-1.5.6
+# or
+docker compose up # optional: -d argument detaches it from terminal
 ```
 
-Where:
-
-- NODE_GITBRANCH = required casper-node branch to build
-- CLIENT_GITBRANCH = required  casper-client-rs to build
+Here are some additional build args:
+```bash
+# Additional build args:
+--build-arg NODE_REPO= # Specify forked/modified node repository
+--build-arg CLIENT_REPO= # Specify forked/modified client repository
+--build-arg NODE_COMMIT= # Specify commit hash from default or custom node repo
+--build-arg CLIENT_COMMIT= # Specify commit hash from default or custom client repo
+--build-arg NODE_GITBRANCH= # Specify branch name
+--build-arg CLIENT_GITBRANCH= # Specify branch name
+```
 
 The build will take approx 30 mins. After this the docker system will store the built layers sensibly negating the need for future full builds.
 
 ### Run
 
-Now we have a built cctl docker image we can run it:
+Now we have a built cctl docker image we can run it using `docker run` or `docker compose up`:
 
-First run the container with the required ports:
-
+Run using `docker run`:
 ```bash
+# Run the container forwarding the required ports
 docker run -it --name cspr-cctl -d -p 25101:25101 -p 11101:11101 -p 14101:14101 -p 18101:18101 cspr-cctl/release-1.5.6
 ```
 
-And test that it's started with one of the following options:
+Run using `docker compose`:
+```bash
+# Docker compose will handle the port forwarding, and will show 'healthy' once the first block is processed
+# Make sure the docker-compose.yaml file is in your current working directory, or specify it using the `-f` flag
+docker compose up -d
+```
+
+And test that it's started with one of the following options, the last is `docker compose` only:
 
 ```bash
 docker exec -t cspr-cctl /bin/bash -c -i 'cctl-infra-net-status'
-```
-
-```bash
+# or
 docker exec -t -i  cspr-cctl /bin/bash
 cctl-infra-net-status
-```
-
-```bash
+# or
 docker logs cspr-cctl
-```
 
-Either way you should see this output:
-
-```bash
+# These will output the following if the network is running:
 validator-group-1:cctl-node-1    RUNNING   pid 639, uptime 0:53:06
 validator-group-1:cctl-node-2    RUNNING   pid 638, uptime 0:53:06
 validator-group-1:cctl-node-3    RUNNING   pid 637, uptime 0:53:06
@@ -59,6 +66,13 @@ validator-group-3:cctl-node-6    STOPPED   Not started
 validator-group-3:cctl-node-7    STOPPED   Not started
 validator-group-3:cctl-node-8    STOPPED   Not started
 validator-group-3:cctl-node-9    STOPPED   Not started
+```
+
+```bash
+# docker compose only, container will say healthy once ready
+docker compose ps
+    NAME          IMAGE                                                                     COMMAND                  SERVICE   CREATED       STATUS                 PORTS
+    kairos-cctl   sha256:6a206d32a671c7c08afbed964ad40f4a3a367afb9060442bb39866d22475c2a2   "/bin/bash -c 'sourc…"   cctl      2 hours ago   Up 2 hours (healthy)   0.0.0.0:11101->11101/tcp, :::11101->11101/tcp, 11102-11105/tcp, 0.0.0.0:14101->14101/tcp, :::14101->14101/tcp, 14102-14105/tcp, 0.0.0.0:18101->18101/tcp, :::18101->18101/tcp, 0.0.0.0:25101->25101/tcp, :::25101->25101/tcp, 18102-18105/tcp
 ```
 
 ### Use
@@ -102,23 +116,3 @@ To view how cctl can be used within a project view the following Terminus SDK te
 ### Pre-built images
 
 Pre-built images can be found [here](https://hub.docker.com/repository/docker/stormeye2000/cspr-cctl/general)
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
- 

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -1,0 +1,28 @@
+version: '3.8'
+services:
+  cctl:
+    build:
+      context: .
+      args:
+        NODE_GITBRANCH: release-1.5.6
+        CLIENT_GITBRANCH: release-2.0.0
+    container_name: cspr-cctl
+    image: cspr-cctl/release-1.5.6
+    ports:
+      - 25101:25101
+      - 11101:11101
+      - 14101:14101
+      - 18101:18101
+    healthcheck:
+      test: |
+        curl --location 'http://localhost:11101/rpc' \
+          --header 'Content-Type: application/json' \
+          --data '{
+              "id": "383766004",
+              "jsonrpc": "2.0",
+              "method": "info_get_status",
+              "params": []
+          }' | jq '.result.available_block_range.high' | grep -q '^1' && echo "Success" && exit 0 || echo "Error" && exit 1
+      interval: 5s
+      retries: 5
+      start_period: 5s


### PR DESCRIPTION
As the title says:

- Added docker-compose.yaml
+ HealthCheck in docker-compose.yaml
+ Build arguments in docker-compose.yaml
- Added REPO build args for both client and node
- Added COMMIT build args for both client and node
- Added documentation pertaining to all of the above in docker/README.md

Reasoning behind these build arguments and docker-compose: 
Allows for easing testing of new and existing apps/contracts/workflows on all versions (including forked versions) of the node and it's software. For example, @jonas089 has a fork of casper-node implementing host functions needed to test kairos.