### PR TITLE
infra-net-setup: don't preserve permissions on any platform

### DIFF
--- a/cmds/infra/net/setup.sh
+++ b/cmds/infra/net/setup.sh
@@ -231,11 +231,8 @@ function _setup_genesis_chainspec()
     local PROTOCOL_VERSION=1.0.0
     local SCRIPT
 
-    if [ "$(get_os)" = "macosx" ]; then
-        cp "$PATH_TO_CHAINSPEC_TEMPLATE" "$PATH_TO_CHAINSPEC"
-    else
-        cp --no-preserve=mode "$PATH_TO_CHAINSPEC_TEMPLATE" "$PATH_TO_CHAINSPEC"
-    fi
+    cp "$PATH_TO_CHAINSPEC_TEMPLATE" "$PATH_TO_CHAINSPEC"
+    chmod 644 "$PATH_TO_CHAINSPEC"
 
     SCRIPT=(
         "import toml;"
@@ -339,11 +336,8 @@ function _setup_node_config()
     cp "$PATH_TO_ASSETS/genesis/accounts.toml" "$PATH_TO_NODE_CONFIG_DIR"
     cp "$PATH_TO_ASSETS/genesis/chainspec.toml" "$PATH_TO_NODE_CONFIG_DIR"
 
-    if [ "$(get_os)" = "macosx" ]; then
-        cp "$PATH_TO_NODE_CONFIG_TEMPLATE" "$PATH_TO_NODE_CONFIG"
-    else
-        cp --no-preserve=mode "$PATH_TO_NODE_CONFIG_TEMPLATE" "$PATH_TO_NODE_CONFIG"
-    fi
+    cp "$PATH_TO_NODE_CONFIG_TEMPLATE" "$PATH_TO_NODE_CONFIG"
+    chmod 644 "$PATH_TO_NODE_CONFIG"
 
     SCRIPT=(
         "import toml;"


### PR DESCRIPTION
The `no-preserve=mode` makes sure that the orignial file permissions are dropped and the users file permissions are used. This is because we copy the asset files from the nix-store, which would require root permissions.

A pipeline which sets up a network, starts it and tears it down can be found here: https://github.com/cspr-rad/kairos/pull/72
Failing pipeline on macos: https://github.com/cspr-rad/kairos/actions/runs/8741663569/job/24028381328
Succeeding pipeline, which uses this PR's changes: https://github.com/cspr-rad/kairos/actions/runs/8788210432/job/24115154594?pr=72