### PR TITLE
Synchronize `dev` with changes on `main`

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,0 +1,41 @@
+name: check
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+jobs:
+  check:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, macos-14]
+    steps:
+      - uses: actions/checkout@v3
+      - uses: DeterminateSystems/nix-installer-action@main
+      - uses: cachix/cachix-action@v12
+        with:
+          name: cspr
+          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+
+      - name: System Info
+        run: |
+          uname -a
+          nix --version
+
+      - name: format
+        if: matrix.os == 'ubuntu-latest'
+        run: nix build -L --no-link --show-trace .#checks.x86_64-linux.format
+
+      - name: cctl (x86_64-linux)
+        if: matrix.os == 'ubuntu-latest'
+        run: nix build -L --no-link --show-trace .#packages.x86_64-linux.cctl
+
+      - name: cctl (x86_64-darwin)
+        if: matrix.os == 'macos-latest'
+        run: nix build -L --no-link --show-trace .#packages.x86_64-darwin.cctl
+
+      - name: cctl aarch64-darwin
+        if: matrix.os == 'macos-14'
+        run: nix build -L --no-link --show-trace .#packages.aarch64-darwin.cctl

--- a/.github/workflows/pre-check.yml
+++ b/.github/workflows/pre-check.yml
@@ -1,0 +1,11 @@
+name: pre-check
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  check-signed-commits:
+    runs-on: ubuntu-latest
+    steps:
+      - name: check signed commits
+        uses: 1Password/check-signed-commits-action@v1

--- a/cmds/infra/net/ctl_setup.sh
+++ b/cmds/infra/net/ctl_setup.sh
@@ -283,11 +283,8 @@ function _setup_genesis_chainspec()
     local PROTOCOL_VERSION=2.0.0
     local SCRIPT
 
-    if [ "$(get_os)" = "macosx" ]; then
-        cp "$PATH_TO_CHAINSPEC_TEMPLATE" "$PATH_TO_CHAINSPEC"
-    else
-        cp --no-preserve=mode "$PATH_TO_CHAINSPEC_TEMPLATE" "$PATH_TO_CHAINSPEC"
-    fi
+    cp "$PATH_TO_CHAINSPEC_TEMPLATE" "$PATH_TO_CHAINSPEC"
+    chmod 644 "$PATH_TO_CHAINSPEC"
 
     SCRIPT=(
         "import toml;"
@@ -378,11 +375,8 @@ function _setup_node_binary_config()
     local SCRIPT
 
     PATH_TO_CONFIG="$(get_path_to_node "$NODE_ID")/config/2_0_0/config.toml"
-    if [ "$(get_os)" = "macosx" ]; then
-        cp "$PATH_TO_TEMPLATE_OF_CONFIG" "$PATH_TO_CONFIG"
-    else
-        cp --no-preserve=mode "$PATH_TO_TEMPLATE_OF_CONFIG" "$PATH_TO_CONFIG"
-    fi
+    cp "$PATH_TO_TEMPLATE_OF_CONFIG" "$PATH_TO_CONFIG"
+    chmod 644 "$PATH_TO_CONFIG"
 
     SCRIPT=(
         "import toml;"


### PR DESCRIPTION
There are two commits that happened directly on `main`, and they are not available on `dev` (which is the branch where development for 2.0 takes place):

- Adding GH actions: https://github.com/casper-network/cctl/commit/06ed0a651edf263b9d92e261ea9c3f7bd973d19a
- Fixing permissions setup: https://github.com/casper-network/cctl/commit/947c34b991e37476db82ccfa2bd7c0312c1a91d7

This PR synchronizes `dev` with the latest `main`.